### PR TITLE
Fix to build on latest pony

### DIFF
--- a/websocket/_http_parser.pony
+++ b/websocket/_http_parser.pony
@@ -49,7 +49,7 @@ class _HttpParser
   fun ref _parse_headers(buffer: Reader): (_HandshakeRequest ref | None) ? =>
     while true do
       try
-        let line = buffer.line()?
+        let line: String = buffer.line()?
         if line.size() == 0 then
           return _request // Finish parsing
         else


### PR DESCRIPTION
the BufferedReader `line` function now returns an iso.

Also a question: does this lib work with SSL/wss? Sorry if that's a dumb question, I don't know much about SSL in pony and websockets in general.