### PR TITLE
Fix in handshake for small number of headers

### DIFF
--- a/websocket/listener.pony
+++ b/websocket/listener.pony
@@ -60,7 +60,10 @@ class _TCPConnectionNotify is TCPConnectionNotify
 
     try
       match _state
-      | _Connecting => _handle_handshake(conn, _buffer)
+      | _Connecting =>
+          while (_buffer.size() > 0) do
+            _handle_handshake(conn, _buffer)
+          end
       | _Open => _handle_frame(conn, _buffer)?
       end
     else


### PR DESCRIPTION
If all the headers fit into the first received buffer, then the request isn't parsed and nothing happens. This patch loops until buffer has been consumed, to handle this case.